### PR TITLE
Add Windows support

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from fairscale.nn.model_parallel.initialize import initialize_model_parallel
 local_rank = int(os.environ.get("LOCAL_RANK", -1))
 world_size = int(os.environ.get("WORLD_SIZE", -1))
 
-torch.distributed.init_process_group("nccl")
+torch.distributed.init_process_group("nccl" if not os.name == "nt" else "gloo")
 initialize_model_parallel(world_size)
 torch.cuda.set_device(local_rank)
 torch.manual_seed(1)


### PR DESCRIPTION
Use gloo on Windows system.

As of PyTorch v1.8, Windows supports all collective communications backend but NCCL (source: https://pytorch.org/docs/stable/distributed.html#backends-that-come-with-pytorch)
